### PR TITLE
Fix method resolution and associate responses with correct callback.

### DIFF
--- a/MetaMaskConnector.js
+++ b/MetaMaskConnector.js
@@ -60,26 +60,27 @@ class MetaMaskConnector {
     } catch (e) {
       throw new Error('Could not parse message from socket. Is it valid JSON?')
     }
-    const { action, payload } = message;
-    return this._handleAction(action, payload);
+    const { action, request_id, payload } = message;
+    return this._handleAction(action, request_id, payload);
   }
-  _handleAction(action, payload) {
+  _handleAction(action, request_id, payload) {
     if (action === 'error') {
       throw new Error(payload);
     }
-    return { responseAction: action, responsePayload: payload };
+    return { responseAction: action, responseRequestId: request_id, responsePayload: payload };
   }
-  send(action, payload, requiredAction) {
+  send(action, request_id, payload, requiredAction) {
     return new Promise((resolve, reject) => {
       const onMsg = msg => {
-        const { responseAction, responsePayload } = this._handleMessage(msg.data);
+        const { responseAction, responseRequestId, responsePayload } = this._handleMessage(msg.data);
+        console.log(`action ${responseAction}, request_id ${responseRequestId}, payload ${JSON.stringify(responsePayload)}`)
         if (requiredAction === responseAction) {
           this._ws.removeEventListener('message', onMsg);
-          resolve(responsePayload);
+          resolve({request_id: responseRequestId, result: responsePayload});
         }
       }
       this._ws.addEventListener('message', onMsg);
-      const msg = JSON.stringify({ action, payload });
+      const msg = JSON.stringify({ action, request_id, payload });
       this._ws.send(msg);
     })
   }

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -1,6 +1,7 @@
 class RemoteMetaMaskProvider {
   constructor(connector) {
     this._connector = connector;
+    this._callbacks = {};
   }
   _getAsyncMethod(method) {
     // Sync methods don't work with MetaMask
@@ -17,31 +18,60 @@ class RemoteMetaMaskProvider {
       'eth_hashrate',
       'eth_gasPrice',
       'eth_accounts',
-      'eth_blocknumber',
+      'eth_blockNumber',
     ];
     const idx = syncMethods.indexOf(method);
     if (idx >= 0) {
       return syncMethods[idx].replace(/(.+)\_([a-z])(.+)/, (str, p1, p2, p3) => `${p1}_get${p2.toUpperCase()}${p3}`)
     }
-    if (method === 'net_version') {
-      // Special MetMask fix
-      method = 'version_getNetwork';
+    const translateMethod = {
+      net_version: 'version_getNetwork',
+      eth_getLogs: 'eth_filter',
+      eth_getTransactionByHash: 'eth_getTransaction'
+    }
+    if (method in translateMethod) {
+      method = translateMethod[method];
     }
     return method;
+  }
+  _guid() {
+    function s4() {
+      return Math.floor((1 + Math.random()) * 0x10000)
+        .toString(16)
+        .substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
   }
   send(payload, callback) {
     if (!this._connector.ready()) {
       return callback(new Error('Can\'t send. Not connected to a MetaMask socket.'))
     }
+    // Because requests are handled across a WebSocket they need to be
+    // associated with their callback with an ID which is returned with the 
+    // response.
+    const request_id = this._guid();
+    this._callbacks[request_id] = callback;
     payload.method = this._getAsyncMethod(payload.method);
-    this._connector.send('execute', payload, 'executed').then(result => {
-      if (result && result.error) return callback(new Error(result.error));
-      callback(null, {
+    this._connector.send('execute', request_id, payload, 'executed').then(({
+      request_id: responseRequestId,
+      result
+    }) => {
+      const request_callback = this._callbacks[responseRequestId];
+      if (request_callback === undefined) {
+        return; // A response for this request was already handled
+      } else {
+        delete this._callbacks[responseRequestId];
+      }
+      if (result && result.error) return request_callback(new Error(result.error));
+      request_callback(null, {
         id: payload.id,
         jsonrpc: '2.0',
         result,
       });
     }).catch(err => callback(err));
+  }
+  sendAsync(payload, callback) {
+    this.send(payload, callback)
   }
 }
 

--- a/client/index.js
+++ b/client/index.js
@@ -6,7 +6,7 @@
     return addLog('Please unlock MetaMask first and then reload this page');
   }
   const socket = new WebSocket('ws://localhost:3333');
-  const reply = (action, payload) => socket.send(JSON.stringify({ action, payload }));
+  const reply = (action, request_id, payload) => socket.send(JSON.stringify({ action, request_id, payload }));
   socket.onmessage = msg => {
     let message;
     try {
@@ -15,24 +15,24 @@
       return addLog('Could not parse websocket message. Is it a proper JSON command?');
     }
     if (message.action === 'execute') {
-      executeAction(message.payload, reply);
+      executeAction(message.request_id, message.payload, reply);
     }
   }
 
-  async function executeAction({ method, params}, reply) {
+  async function executeAction(request_id, { method, params}, reply) {
     let result;
-    addLog(`Calling ${method} with ${JSON.stringify(params)}`);
+    addLog(`Request ${request_id} Calling ${method} with ${JSON.stringify(params)}`);
     try {
-      result = await execute(method, params);
+      result = await execute(request_id, method, params);
     } catch(e) {
-      return reply('executed', {
+      return reply('executed', request_id, {
         error: e.message
       });
     }
-    reply('executed', result);
+    reply('executed', request_id, result);
   }
 
-  function execute(method, params) {
+  function execute(request_id, method, params) {
     return new Promise((resolve, reject) => {
       const splitMethod = method.split('_');
       const scope = splitMethod[0];
@@ -41,6 +41,7 @@
         if (err) {
           return reject(err);
         }
+        addLog(`Result from ${request_id} ${method}: ${JSON.stringify(result)}`);
         resolve(result);
       })
       try {


### PR DESCRIPTION
This addresses the following issues:
- Fix typo in eth_blocknumber -> eth_blockNumber
- Handle requests for eth_getLogs and eth_getTransactionByHash
- Add support for Web3 v0.x providors by supporting sendAsync
- Create UUID for each request and map to callback given when request was made.
  This is needed to ensure that the correct response for the original request is sent to the original requestor.

Addresses https://github.com/JoinColony/node-metamask/issues/3