### PR TITLE
Fix undefined request callback method

### DIFF
--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -56,6 +56,7 @@ class RemoteMetaMaskProvider {
       requestId: responseRequestId,
       result
     }) => {
+      const requestCallback = this._callbacks.get(responseRequestId);
       if (!this._callbacks.has(responseRequestId)) {
         return; // A response for this request was already handled
       } else {


### PR DESCRIPTION
## Description

Fixes `ReferenceError: requestCallback is not defined`

Adds `const requestCallback = this._callbacks.get(responseRequestId);`

Closes #3