### PR TITLE
Ensure access to MetaMask is granted before requesting

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -10,13 +10,15 @@
     document.querySelector('#messages').appendChild(logEntry);
   };
 
-  const checkUnlocked = () =>
-    new Promise((resolve, reject) => {
+  const checkUnlocked = async () => {
+    await window.ethereum.enable() // Ensure access to MetaMask
+    return new Promise((resolve, reject) => {
       web3.eth.getAccounts((err, accounts) => {
         if (err) return reject(err);
         return resolve(accounts && !!accounts[0]);
       });
     });
+  };
 
   const execute = (requestId, method, params) =>
     new Promise((resolve, reject) => {

--- a/client/index.js
+++ b/client/index.js
@@ -11,7 +11,9 @@
   };
 
   const checkUnlocked = async () => {
-    await window.ethereum.enable() // Ensure access to MetaMask
+    if(w.ethereum) {
+      await w.ethereum.enable() // Ensure access to MetaMask
+    }
     return new Promise((resolve, reject) => {
       web3.eth.getAccounts((err, accounts) => {
         if (err) return reject(err);

--- a/client/index.js
+++ b/client/index.js
@@ -11,8 +11,8 @@
   };
 
   const checkUnlocked = async () => {
-    if(w.ethereum) {
-      await w.ethereum.enable() // Ensure access to MetaMask
+    if (w.ethereum) {
+      await w.ethereum.enable(); // Ensure access to MetaMask
     }
     return new Promise((resolve, reject) => {
       web3.eth.getAccounts((err, accounts) => {


### PR DESCRIPTION
Privacy mode in MetaMask requires the app to explicitly request access to MetaMask before interaction. See https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8.
This mode will soon be enabled by default.
This PR adds the request for permission so that if required, permissions can be accepted.

The Impact: The connector always stays stuck at the following message, if privacy mode is enabled:

> Please unlock MetaMask first and then reload this page

Please unlock MetaMask first and then reload this page

To test this, you can enable Privacy Mode in MetaMask and open up the connector page.