### PR TITLE
When dealing with very large numbers (>= 1e+21), `result` in the `send()` method fails to convert scientific notation to a number, creating downstream BigNumber conversion errors

### DIFF
--- a/FromExponential.js
+++ b/FromExponential.js
@@ -1,0 +1,33 @@
+// src: https://gist.github.com/jiggzson/b5f489af9ad931e3d186
+const SCIENTIFIC_NUMBER_REGEX = /\d+\.?\d*e[\+\-]*\d+/i;
+
+// Convert from scientific notation into a number
+// e.g. from 9.99998934104e+21 to 9999989341040000000000
+const scientificToDecimal = function(number) {
+    let numberHasSign = number.startsWith("-") || number.startsWith("+");
+    let sign = numberHasSign ? number[0] : "";
+    number = numberHasSign ? number.replace(sign, "") : number;
+
+    //if the number is in scientific notation remove it
+    if (SCIENTIFIC_NUMBER_REGEX.test(number)) {
+        let zero = '0';
+        let parts = String(number).toLowerCase().split('e'); //split into coeff and exponent
+        let e = parts.pop();//store the exponential part
+        let l = Math.abs(e); //get the number of zeros
+        let sign = e / l;
+        let coeff_array = parts[0].split('.');
+
+        if (sign === -1) {
+            coeff_array[0] = Math.abs(coeff_array[0]);
+            number = zero + '.' + new Array(l).join(zero) + coeff_array.join('');
+        } else {
+            let dec = coeff_array[1];
+            if (dec) l = l - dec.length;
+            number = coeff_array.join('') + new Array(l + 1).join(zero);
+        }
+    }
+
+    return `${sign}${number}`;
+};
+
+module.exports = scientificToDecimal;

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -1,4 +1,4 @@
-// const fromExponential = require('./FromExponential');
+const fromExponential = require('./FromExponential');
 
 class RemoteMetaMaskProvider {
   constructor(connector) {

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -1,4 +1,4 @@
-const fromExponential = require('./FromExponential');
+// const fromExponential = require('./FromExponential');
 
 class RemoteMetaMaskProvider {
   constructor(connector) {
@@ -76,12 +76,12 @@ class RemoteMetaMaskProvider {
     // Format for "eth_filter"
     if (result && result.logIndex) return [result];
 
-    // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
-    // then it back into a number form so that it can be used by ethers' bignumber type
-    // e.g. from 9.99862115952e+21 to 9998621159520000000000
-    if (result && !isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
-     return fromExponential(result);
-    } 
+    // // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
+    // // then it back into a number form so that it can be used by ethers' bignumber type
+    // // e.g. from 9.99862115952e+21 to 9998621159520000000000
+    // if (result && !isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
+    //  return fromExponential(result);
+    // } 
 
     return result;
   }

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -76,12 +76,12 @@ class RemoteMetaMaskProvider {
     // Format for "eth_filter"
     if (result && result.logIndex) return [result];
 
-    // // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
-    // // then it back into a number form so that it can be used by ethers' bignumber type
-    // // e.g. from 9.99862115952e+21 to 9998621159520000000000
-    // if (result && !isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
-    //  return fromExponential(result);
-    // } 
+    // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
+    // then it back into a number form so that it can be used by ethers' bignumber type
+    // e.g. from 9.99862115952e+21 to 9998621159520000000000
+    if (result && !isNaN(result)) {
+     return fromExponential(result);
+    } 
 
     return result;
   }

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -76,12 +76,12 @@ class RemoteMetaMaskProvider {
     // Format for "eth_filter"
     if (result && result.logIndex) return [result];
 
-    // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
-    // then it back into a number form so that it can be used by ethers' bignumber type
+    // If result is in scientific notation,
+    // then convert it into number form so that it can be used by ethers' bignumber type
     // e.g. from 9.99862115952e+21 to 9998621159520000000000
-    if (result && !isNaN(result)) {
-     return fromExponential(result);
-    } 
+    if (result && !isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x'))) {
+      return fromExponential(result);
+    }
 
     return result;
   }

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -79,8 +79,8 @@ class RemoteMetaMaskProvider {
     // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
     // then it back into a number form so that it can be used by ethers' bignumber type
     // e.g. from 9.99862115952e+21 to 9998621159520000000000
-    if (!isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
-     return fromExponential(result)
+    if (result && !isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
+     return fromExponential(result);
     } 
 
     return result;

--- a/RemoteMetaMaskProvider.js
+++ b/RemoteMetaMaskProvider.js
@@ -1,3 +1,5 @@
+const fromExponential = require('./FromExponential');
+
 class RemoteMetaMaskProvider {
   constructor(connector) {
     this._connector = connector;
@@ -73,6 +75,13 @@ class RemoteMetaMaskProvider {
 
     // Format for "eth_filter"
     if (result && result.logIndex) return [result];
+
+    // If result is a number in scientific notation, which nodeJS might automatically convert it into if it is >= 1e21,
+    // then it back into a number form so that it can be used by ethers' bignumber type
+    // e.g. from 9.99862115952e+21 to 9998621159520000000000
+    if (!isNaN(result) && (typeof result === 'string') && (!result.startsWith('0x')) && (Number(result) >= 1e21)) {
+     return fromExponential(result)
+    } 
 
     return result;
   }


### PR DESCRIPTION
## Description

First of all, thank you for building this package in the first place, it is really awesome! 💯 

I ran into this error when using the MetaMask provider and calling `web3.eth.getBalanceOf(address)` on an account with a lot of ETH. I seed all of my GanacheCLI accounts with 10,000 ETH so I ran into this error easily. I encountered BigNumber conversion errors, complaining that I was trying to convert a scientific-notation number, for example  "9.988e+22", into a BN. I added a fix to detect if `result` is a number in scientific notation and to subsequently convert it. 

Specific edits:
- Created a file to convert between exponential/scientific notation and numbers
- Checked whether `result` in `send()` is in scientific notation, which is possible I believe because nodeJS sometimes automatically converts numbers >= 1e21 into scientific notation. See more [here](https://stackoverflow.com/questions/1685680/how-to-avoid-scientific-notation-for-large-numbers-in-javascript)
- To replicate the error, call `web3.eth.getBalanceOf(address)` on an `address` with a lot of ETH. 

## Other Changes


## Checklist


## Scripts


**Added Scripts**:

**Updated Scripts**:

## Dependencies

**Added Dependencies**:

**Updated Dependencies**:

## Related Issues

